### PR TITLE
Eliminating warnings from the Xtend code base

### DIFF
--- a/com.wamas.ide.launching.ide/src/com/wamas/ide/launching/ide/LcDslIdeModule.xtend
+++ b/com.wamas.ide.launching.ide/src/com/wamas/ide/launching/ide/LcDslIdeModule.xtend
@@ -3,7 +3,6 @@
  */
 package com.wamas.ide.launching.ide
 
-
 /**
  * Use this class to register ide components.
  */

--- a/com.wamas.ide.launching.ui/src/com/wamas/ide/launching/ui/LcDslUiModule.xtend
+++ b/com.wamas.ide.launching.ui/src/com/wamas/ide/launching/ui/LcDslUiModule.xtend
@@ -3,10 +3,10 @@
  */
 package com.wamas.ide.launching.ui
 
+import com.wamas.ide.launching.ui.hyperlink.LcDslHyperlinkHelper
 import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 import org.eclipse.xtext.generator.IShouldGenerate
 import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkHelper
-import com.wamas.ide.launching.ui.hyperlink.LcDslHyperlinkHelper
 
 /**
  * Use this class to register components to be used within the Eclipse IDE.

--- a/com.wamas.ide.launching.ui/src/com/wamas/ide/launching/ui/contentassist/LcDslProposalProvider.xtend
+++ b/com.wamas.ide.launching.ui/src/com/wamas/ide/launching/ui/contentassist/LcDslProposalProvider.xtend
@@ -43,15 +43,15 @@ import org.eclipse.xtext.ui.editor.contentassist.ConfigurableCompletionProposal
 class LcDslProposalProvider extends AbstractLcDslProposalProvider {
 
 	@Inject
-	private IImageHelper ih
+	IImageHelper ih
 
 	@Inject
-	private extension LcDslGrammarAccess ga
+	extension LcDslGrammarAccess ga
 	
 	override complete_Project(EObject model, RuleCall ruleCall, ContentAssistContext context,
 		ICompletionProposalAcceptor acceptor) {
 		for (prj : ResourcesPlugin.workspace.root.projects) {
-			if (prj != null && prj.exists && prj.open && JavaProject.hasJavaNature(prj)) {
+			if (prj !== null && prj.exists && prj.open && JavaProject.hasJavaNature(prj)) {
 				acceptor.accept(
 					createCompletionProposal(prj.name, new StyledString(prj.name), ih.getImage("showprojects.gif"),
 						context))
@@ -92,7 +92,7 @@ class LcDslProposalProvider extends AbstractLcDslProposalProvider {
 		val pv = model as PluginWithVersion
 		val models = PluginRegistry.findModels(pv.name, null, IMatchRules.NONE, null)
 
-		if (models != null && !models.empty) {
+		if (models !== null && !models.empty) {
 			for (m : models) {
 				val ver = m.bundleDescription.version.toString
 				acceptor.accept(
@@ -129,7 +129,7 @@ class LcDslProposalProvider extends AbstractLcDslProposalProvider {
 		val f = model as FeatureWithVersion
 		val models = PDECore.^default.featureModelManager.findFeatureModels(f.name)
 
-		if (models != null && !models.empty) {
+		if (models !== null && !models.empty) {
 			for (m : models) {
 				val ver = m.feature.version
 				acceptor.accept(
@@ -189,10 +189,10 @@ class LcDslProposalProvider extends AbstractLcDslProposalProvider {
 			val lc = model.eContainer as LaunchConfig
 			val mainprj = RecursiveCollectors.collectJavaMainProject(lc)
 
-			if (mainprj != null) {
+			if (mainprj !== null) {
 				// project is set, lookup main types.
 				val prj = ResourcesPlugin.workspace.root.getProject(mainprj)
-				if (prj != null && prj.exists && prj.open) {
+				if (prj !== null && prj.exists && prj.open) {
 					val jp = JavaCore.create(prj)
 
 					// source scope for the relevant project
@@ -202,7 +202,7 @@ class LcDslProposalProvider extends AbstractLcDslProposalProvider {
 					val engine = new SearchEngine()
 
 					engine.search(pattern, #{SearchEngine.defaultSearchParticipant}, scope, [ m |
-						if (m.element != null && m.element instanceof IMethod) {
+						if (m.element !== null && m.element instanceof IMethod) {
 							val ele = m.element as IMethod
 							if (ele.mainMethod) {
 								val fullName = ele.declaringType.fullyQualifiedName
@@ -318,8 +318,8 @@ class LcDslProposalProvider extends AbstractLcDslProposalProvider {
 
 		private static class DescribingAcceptor extends Delegate {
 
-			private Keyword kw
-			private extension LcDslGrammarAccess ga
+			Keyword kw
+			extension LcDslGrammarAccess ga
 
 			new(ICompletionProposalAcceptor delegate, Keyword kw, LcDslGrammarAccess ga) {
 				super(delegate)

--- a/com.wamas.ide.launching.ui/src/com/wamas/ide/launching/ui/hyperlink/LcDslHyperlinkHelper.xtend
+++ b/com.wamas.ide.launching.ui/src/com/wamas/ide/launching/ui/hyperlink/LcDslHyperlinkHelper.xtend
@@ -5,25 +5,23 @@ package com.wamas.ide.launching.ui.hyperlink
 
 import com.google.inject.Inject
 import com.google.inject.Provider
-import com.wamas.ide.launching.lcDsl.LcDslPackage
+import com.wamas.ide.launching.lcDsl.FeatureWithVersion
 import com.wamas.ide.launching.lcDsl.Path
+import com.wamas.ide.launching.lcDsl.PluginWithVersion
 import com.wamas.ide.launching.lcDsl.StringWithVariables
+import java.io.File
 import org.eclipse.core.internal.variables.StringVariableManager
+import org.eclipse.core.resources.ResourcesPlugin
 import org.eclipse.jface.text.IRegion
 import org.eclipse.jface.text.Region
+import org.eclipse.pde.core.plugin.IMatchRules
+import org.eclipse.pde.core.plugin.PluginRegistry
+import org.eclipse.pde.internal.core.PDECore
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils
 import org.eclipse.xtext.resource.EObjectAtOffsetHelper
 import org.eclipse.xtext.resource.XtextResource
 import org.eclipse.xtext.ui.editor.hyperlinking.HyperlinkHelper
 import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkAcceptor
-import java.io.File
-import org.eclipse.core.resources.ResourcesPlugin
-import com.wamas.ide.launching.lcDsl.PluginWithVersion
-import org.eclipse.pde.core.plugin.PluginRegistry
-import org.eclipse.pde.core.plugin.IMatchRules
-import org.eclipse.pde.internal.ui.editor.plugin.ManifestEditor
-import com.wamas.ide.launching.lcDsl.FeatureWithVersion
-import org.eclipse.pde.internal.core.PDECore
 
 class LcDslHyperlinkHelper extends HyperlinkHelper {
 

--- a/com.wamas.ide.launching.ui/src/com/wamas/ide/launching/ui/labeling/LcDslLabelProvider.xtend
+++ b/com.wamas.ide.launching.ui/src/com/wamas/ide/launching/ui/labeling/LcDslLabelProvider.xtend
@@ -39,7 +39,6 @@ import org.eclipse.debug.internal.ui.DebugPluginImages
 import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider
 import org.eclipse.jface.viewers.StyledString
 import org.eclipse.xtext.ui.label.DefaultEObjectLabelProvider
-import org.eclipse.xtext.naming.IQualifiedNameProvider
 
 /**
  * Provides labels for EObjects.
@@ -81,7 +80,7 @@ class LcDslLabelProvider extends DefaultEObjectLabelProvider {
 
 	def image(LaunchConfig lc) {
 		val img = DebugPluginImages.getImage(StandaloneLaunchConfigGenerator.getTypeName(lc.type))
-		if (img == null)
+		if (img === null)
 			return "message_warning.gif"
 		img
 	}
@@ -89,10 +88,10 @@ class LcDslLabelProvider extends DefaultEObjectLabelProvider {
 	def text(Redirect r) {
 		val builder = new StringBuilder
 		builder.append("redirect")
-		if (r.outFile != null) {
+		if (r.outFile !== null) {
 			builder.append(' ').append(r.outWhich.literal).append(" to ").append(r.outFile.name.value)
 		}
-		if (r.inFile != null) {
+		if (r.inFile !== null) {
 			builder.append(' ').append(r.inWhich.literal).append(" from ").append(r.inFile.name.value)
 		}
 		builder.toString
@@ -122,7 +121,7 @@ class LcDslLabelProvider extends DefaultEObjectLabelProvider {
 		val p = a.plugin
 		val ss = new StyledString
 		ss.append("plugin ").append(p.plugin.name)
-		if (p.plugin.version != null)
+		if (p.plugin.version !== null)
 			ss.append(' ').append(p.plugin.version, StyledString.QUALIFIER_STYLER)
 
 		if (p.autoStart)
@@ -143,7 +142,7 @@ class LcDslLabelProvider extends DefaultEObjectLabelProvider {
 
 	def text(AddFeature a) {
 		val ss = new StyledString("feature " + a.feature.name)
-		if (a.feature.version != null)
+		if (a.feature.version !== null)
 			ss.append(' ').append(a.feature.version, StyledString.QUALIFIER_STYLER)
 
 		ss
@@ -167,7 +166,7 @@ class LcDslLabelProvider extends DefaultEObjectLabelProvider {
 	def text(IgnorePlugin i) {
 		val ss = new StyledString
 		ss.append("ignore ").append(i.plugin.name)
-		if (i.plugin.version != null)
+		if (i.plugin.version !== null)
 			ss.append(' ').append(i.plugin.version, StyledString.QUALIFIER_STYLER)
 		ss
 	}
@@ -330,7 +329,7 @@ class LcDslLabelProvider extends DefaultEObjectLabelProvider {
 		else
 			ss.append("]", StyledString.QUALIFIER_STYLER)
 
-		if (m.postAction != null) {
+		if (m.postAction !== null) {
 			ss.append(" [" + m.postAction.text() + "]", StyledString.DECORATIONS_STYLER)
 		}
 

--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/LcDslRuntimeModule.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/LcDslRuntimeModule.xtend
@@ -3,8 +3,8 @@
  */
 package com.wamas.ide.launching
 
-import org.eclipse.xtext.naming.IQualifiedNameProvider
 import com.wamas.ide.launching.naming.LcDslQualifiedNameProvider
+import org.eclipse.xtext.naming.IQualifiedNameProvider
 import org.eclipse.xtext.resource.impl.SimpleResourceDescriptionsBasedContainerManager
 
 /**

--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/LcDslStandaloneSetup.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/LcDslStandaloneSetup.xtend
@@ -3,7 +3,6 @@
  */
 package com.wamas.ide.launching
 
-
 /**
  * Initialization support for running Xtext languages without Equinox extension registry.
  */

--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/DependencyResolver.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/DependencyResolver.xtend
@@ -25,7 +25,7 @@ import static extension com.wamas.ide.launching.generator.RecursiveCollectors.*
 
 class DependencyResolver {
 
-	private static val log = Logger.getLogger(DependencyResolver)
+	static val log = Logger.getLogger(DependencyResolver)
 
 	static class StartLevel {
 		boolean autostart = false;

--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/LcDslGenerator.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/LcDslGenerator.xtend
@@ -4,15 +4,15 @@
 package com.wamas.ide.launching.generator
 
 import com.google.inject.Inject
+import com.wamas.ide.launching.Activator
 import com.wamas.ide.launching.lcDsl.LaunchConfig
+import java.util.List
+import org.eclipse.core.runtime.IStatus
+import org.eclipse.debug.core.DebugPlugin
 import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.xtext.generator.AbstractGenerator
 import org.eclipse.xtext.generator.IFileSystemAccess2
 import org.eclipse.xtext.generator.IGeneratorContext
-import org.eclipse.debug.core.DebugPlugin
-import java.util.List
-import com.wamas.ide.launching.Activator
-import org.eclipse.core.runtime.IStatus
 
 /**
  * Generates code from your model files on save.
@@ -24,7 +24,7 @@ class LcDslGenerator extends AbstractGenerator {
 	@Inject
 	extension StandaloneLaunchConfigGenerator generator
 
-	private static List<Runnable> listeners = newArrayList
+	static List<Runnable> listeners = newArrayList
 
 	override void doGenerate(Resource resource, IFileSystemAccess2 fsa, IGeneratorContext context) {
 		for (x : resource.allContents.filter(typeof(LaunchConfig)).toIterable) {

--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/RecursiveCollectors.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/RecursiveCollectors.xtend
@@ -6,6 +6,7 @@ package com.wamas.ide.launching.generator
 import com.wamas.ide.launching.lcDsl.EnvironmentVariable
 import com.wamas.ide.launching.lcDsl.LaunchConfig
 import com.wamas.ide.launching.lcDsl.LaunchModeType
+import com.wamas.ide.launching.lcDsl.PluginWithVersion
 import java.util.List
 import java.util.Map
 import java.util.function.Function
@@ -13,12 +14,10 @@ import org.eclipse.core.resources.ResourcesPlugin
 import org.eclipse.core.runtime.Path
 import org.eclipse.debug.ui.IDebugUIConstants
 import org.eclipse.jdt.launching.JavaRuntime
+import org.osgi.framework.Version
 
 import static extension com.wamas.ide.launching.validation.LcDslValidator.getExpanded
 import static extension com.wamas.ide.launching.validation.LcDslValidator.mapSaveSuperConfig
-import com.wamas.ide.launching.validation.LcDslValidator
-import com.wamas.ide.launching.lcDsl.PluginWithVersion
-import org.osgi.framework.Version
 
 /**
  * Collects raw values for launch configuration fields, taking into account inheritance
@@ -299,7 +298,7 @@ class RecursiveCollectors {
 		if (o !== null)
 			return o
 
-		if (config.mapSaveSuperConfig != null)
+		if (config.mapSaveSuperConfig !== null)
 			return collectFlatObject(config.mapSaveSuperConfig, extractor)
 
 		return null;

--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/StandaloneLaunchConfigGenerator.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/generator/StandaloneLaunchConfigGenerator.xtend
@@ -15,6 +15,7 @@ import com.wamas.ide.launching.lcDsl.LaunchConfigType
 import com.wamas.ide.launching.services.LcDslPostProcessor
 import java.io.File
 import java.util.Map
+import java.util.TreeSet
 import org.eclipse.core.resources.ResourcesPlugin
 import org.eclipse.core.runtime.IStatus
 import org.eclipse.debug.core.DebugPlugin
@@ -28,27 +29,26 @@ import org.eclipse.emf.common.util.Diagnostic
 import org.eclipse.emf.ecore.util.Diagnostician
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants
 import org.eclipse.pde.core.plugin.PluginRegistry
+import org.eclipse.pde.core.plugin.TargetPlatform
 import org.eclipse.pde.internal.core.product.WorkspaceProductModel
+import org.eclipse.pde.internal.launching.IPDEConstants
 import org.eclipse.pde.launching.IPDELauncherConstants
 import org.eclipse.pde.ui.launcher.EclipseLaunchShortcut
 import org.eclipse.xtext.naming.IQualifiedNameProvider
 
 import static extension com.wamas.ide.launching.generator.RecursiveCollectors.*
-import org.eclipse.pde.core.plugin.TargetPlatform
-import java.util.TreeSet
-import org.eclipse.pde.internal.launching.IPDEConstants
 
 class StandaloneLaunchConfigGenerator {
 
 	@Inject
 	extension IQualifiedNameProvider qnp
 
-	private val knownStartLevels = newHashMap(
+	val knownStartLevels = newHashMap(
 		"org.eclipse.osgi" -> "@-1:true",
 		"org.eclipse.equinox.ds" -> "@1:true",
 		"org.eclipse.equinox.common" -> "@2:true"
 	)
-	private val launchMgr = DebugPlugin.^default.launchManager
+	val launchMgr = DebugPlugin.^default.launchManager
 
 	public static final String CONFIGURATION_TYPE_RAP = "org.eclipse.rap.ui.launch.RAPLauncher";
 	public static final String CONFIGURATION_TYPE_GROUP = "org.eclipse.debug.core.groups.GroupLaunchConfigurationType";
@@ -78,7 +78,7 @@ class StandaloneLaunchConfigGenerator {
 		if (config === null || config.abstract)
 			return null;
 
-		if (config.hasError || config.fullName == null) {
+		if (config.hasError || config.fullName === null) {
 			Activator.log(IStatus.ERROR, "launch configuration has errors, not generating " + config.fullName, null)
 			return null;
 		}

--- a/com.wamas.ide.launching/src/com/wamas/ide/launching/validation/LcDslValidator.xtend
+++ b/com.wamas.ide.launching/src/com/wamas/ide/launching/validation/LcDslValidator.xtend
@@ -14,6 +14,7 @@ import com.wamas.ide.launching.lcDsl.ExistingPath
 import com.wamas.ide.launching.lcDsl.Favorites
 import com.wamas.ide.launching.lcDsl.FeatureWithVersion
 import com.wamas.ide.launching.lcDsl.GroupMember
+import com.wamas.ide.launching.lcDsl.IgnorePlugin
 import com.wamas.ide.launching.lcDsl.LaunchConfig
 import com.wamas.ide.launching.lcDsl.LcDslPackage
 import com.wamas.ide.launching.lcDsl.PluginWithVersion
@@ -37,7 +38,6 @@ import org.eclipse.pde.internal.core.PDECore
 import org.eclipse.xtext.validation.Check
 
 import static com.wamas.ide.launching.lcDsl.LaunchConfigType.*
-import com.wamas.ide.launching.lcDsl.IgnorePlugin
 
 /**
  * This class contains custom validation rules. 
@@ -46,13 +46,13 @@ import com.wamas.ide.launching.lcDsl.IgnorePlugin
  */
 class LcDslValidator extends AbstractLcDslValidator {
 
-	public static final val EXT_APPLICATIONS = "org.eclipse.core.runtime.applications"
-	public static final val EXT_PRODUCTS = "org.eclipse.core.runtime.products"
+	public static val EXT_APPLICATIONS = "org.eclipse.core.runtime.applications"
+	public static val EXT_PRODUCTS = "org.eclipse.core.runtime.products"
 
-	private LcDslPackage LC = LcDslPackage.eINSTANCE
+	LcDslPackage LC = LcDslPackage.eINSTANCE
 
 	// map config features to types where this feature is allowed. not mentioned features are allowed on all types.
-	private val allowedFeatures = newHashMap(
+	val allowedFeatures = newHashMap(
 		// modifiers on config
 		LC.launchConfig_Explicit -> #{ECLIPSE, RAP},
 		LC.launchConfig_NoConsole -> #{ECLIPSE, RAP, JAVA},
@@ -86,7 +86,7 @@ class LcDslValidator extends AbstractLcDslValidator {
 		LC.launchConfig_Traces -> #{ECLIPSE, RAP}
 	)
 
-	private val requiredFeatures = newHashMap(
+	val requiredFeatures = newHashMap(
 		ECLIPSE -> #{
 			#{LC.launchConfig_Application, LC.launchConfig_Product},
 			#{LC.launchConfig_Plugins, LC.launchConfig_Features, LC.launchConfig_ContentProviderProduct}


### PR DESCRIPTION
- Organizing the import statements, eliminate unused imports.
- Fixing warnings: the operator '!=' should be replaced by '!==' when
null is one of the arguments.
- Fixing warnings: the private modifier is unnecessary on fields.
- Fixing warnings: the final modifier is unnecessary if the val modifier
is present.