### PR TITLE
pin used github actions to commit ids

### DIFF
--- a/.github/workflows/maven-pr.yml
+++ b/.github/workflows/maven-pr.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -37,7 +37,7 @@ jobs:
       env:
         PR_NUMBER: ${{ github.event.number }}
     - name: Archive Build Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:
         name: p2-repository
         path: com.wamas.ide.launching.update/target/repository/

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -42,7 +42,7 @@ jobs:
         sed -i 's,/features/,/,g' artifacts.xml
         rm -r plugins features
     - name: Archive Build Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:
         name: p2-repository
         path: com.wamas.ide.launching.update/target/repository/


### PR DESCRIPTION
to avoid situations like the Trivy security incident